### PR TITLE
use array access as default is a reserved keyword

### DIFF
--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -101,7 +101,7 @@
           this.el().appendChild(label);
         }else{
           var staticLabel = document.createElement('span');
-          staticLabel.classList.add('vjs-resolution-button-staticlabel');
+          staticLabel.className = 'vjs-resolution-button-staticlabel';
           this.el().appendChild(staticLabel);
         }
        },
@@ -142,7 +142,7 @@
           player = this,
           label = document.createElement('span');
   
-      label.classList.add('vjs-resolution-button-label');
+      label.className = 'vjs-resolution-button-label';
       
       /**
        * Updates player sources or returns current source URL
@@ -162,7 +162,7 @@
         var groupedSrc = bucketSources(src);
         var choosen = chooseSrc(groupedSrc, src);
         var menuButton = new ResolutionMenuButton(player, { sources: groupedSrc, initialySelectedLabel: choosen.label , initialySelectedRes: choosen.res }, settings, label);
-        menuButton.el().classList.add('vjs-resolution-button');
+        menuButton.el().className += ' vjs-resolution-button';
         player.controlBar.resolutionSwitcher = player.controlBar.addChild(menuButton);
         return setSourcesSanitized(player, choosen.sources, choosen.label);
       };

--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -231,7 +231,7 @@
        * @returns {Object} {res: string, sources: []}
        */
       function chooseSrc(groupedSrc, src){
-        var selectedRes = settings.default;
+        var selectedRes = settings['default']; // use array access as default is a reserved keyword
         var selectedLabel = '';
         if (selectedRes === 'high') {
           selectedRes = src[0].res;

--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -101,7 +101,7 @@
           this.el().appendChild(label);
         }else{
           var staticLabel = document.createElement('span');
-          staticLabel.className = 'vjs-resolution-button-staticlabel';
+          staticLabel.classList.add('vjs-resolution-button-staticlabel');
           this.el().appendChild(staticLabel);
         }
        },
@@ -142,7 +142,7 @@
           player = this,
           label = document.createElement('span');
   
-      label.className = 'vjs-resolution-button-label';
+      label.classList.add('vjs-resolution-button-label');
       
       /**
        * Updates player sources or returns current source URL
@@ -162,7 +162,7 @@
         var groupedSrc = bucketSources(src);
         var choosen = chooseSrc(groupedSrc, src);
         var menuButton = new ResolutionMenuButton(player, { sources: groupedSrc, initialySelectedLabel: choosen.label , initialySelectedRes: choosen.res }, settings, label);
-        menuButton.el().className += ' vjs-resolution-button';
+        menuButton.el().classList.add('vjs-resolution-button');
         player.controlBar.resolutionSwitcher = player.controlBar.addChild(menuButton);
         return setSourcesSanitized(player, choosen.sources, choosen.label);
       };


### PR DESCRIPTION
while this is not an issue with up-to-date major browsers, I still think this fix is necessary. It does not allow native support for browsers older internet explorer versions but allows polyfilling, while accessing Obj.default creates a non-restorable syntax error (expected identifier) in IE8 and lower and thus makes the plugin completely unusable.