### PR TITLE
disable the text-transform CSS property for the resolution menu

### DIFF
--- a/lib/videojs-resolution-switcher.css
+++ b/lib/videojs-resolution-switcher.css
@@ -28,3 +28,7 @@
 .vjs-resolution-button .vjs-menu {
   left: 0;
 }
+
+.vjs-resolution-button .vjs-menu li {
+  text-transform: none;
+}


### PR DESCRIPTION
The default skin has `text-transform: lowercase` for menu items. So if one uses "HD" and "SD" as  resolution labels, it will render as "hd" and "sd" by default.
Override the property so no transformation occurs and the labels show as the user wants them to show.