### PR TITLE
Design fix: Vertically center label text

### DIFF
--- a/lib/videojs-resolution-switcher.css
+++ b/lib/videojs-resolution-switcher.css
@@ -11,7 +11,7 @@
 
 .vjs-resolution-button .vjs-resolution-button-label {
     font-size: 1.2em;
-    line-height: 2.50em;
+    line-height: 2.30em;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
The text of the resolution select button is not centered vertically. Decrease the line-height just a little bit so it looks better.