### PR TITLE
Move dependency on grunt to "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-    "grunt": "^0.4.5"
-  },
   "devDependencies": {
+    "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.7",
     "grunt-contrib-concat": "^0.5",
     "grunt-contrib-jshint": "^0.12",


### PR DESCRIPTION
Package "grunt" is not used outside of the development workflow. Therefore it doesn't make sense for the "grunt" to be included as a direct package dependency. Now everyone that is willing to use this package needs to pull in "grunt" which is undesirable.