### PR TITLE
Only add sources if the type is supported by a Tech

### DIFF
--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -178,6 +178,15 @@
           player.controlBar.resolutionSwitcher.dispose();
           delete player.controlBar.resolutionSwitcher;
         }
+        // Only add those sources which we can (maybe) play
+        src = src.filter( function(source) {
+          try {
+            return ( player.canPlayType( source.type ) !== '' );
+          } catch (e) {
+            // If a Tech doesn't yet have canPlayType just add it
+            return true;
+          }
+        });
         //Sort sources
         src = src.sort(compareResolutions);
         groupedSrc = bucketSources(src);


### PR DESCRIPTION
There is not much use in adding sources that we cannot play, so filter
them out. Backwards compatible with Tech's that do not yet support
canPlayType().

Fixes #15