### PR TITLE
Fix issue 109 - plugin() deprecated on videojs plugin

### DIFF
--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -362,6 +362,6 @@
     };
 
     // register the plugin
-    videojs.plugin('videoJsResolutionSwitcher', videoJsResolutionSwitcher);
+    videojs.registerPlugin('videoJsResolutionSwitcher', videoJsResolutionSwitcher);
   })(window, videojs);
 })();


### PR DESCRIPTION
Fix issue 109 - plugin() deprecated on videojs plugin.

Just replacing the new function name for registering a plugin on videojs.