### PR TITLE
Adding a new 1440p resolution

### DIFF
--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -281,6 +281,7 @@
         // Map youtube qualities names
         var _yts = {
           highres: {res: 1080, label: '1080', yt: 'highres'},
+          hd1440: {res: 1440, label: '1440', yt: 'hd1440'},
           hd1080: {res: 1080, label: '1080', yt: 'hd1080'},
           hd720: {res: 720, label: '720', yt: 'hd720'},
           large: {res: 480, label: '480', yt: 'large'},


### PR DESCRIPTION
This commit fixes an error, for cases when the video comes in a resolution greater than 1080p.

VIDEOJS: ERROR: TypeError: Cannot read property 'label' of undefined
    at videojs-resolution-switcher.js?W:323
    at Array.map (<anonymous>)
    at b.<anonymous> (videojs-resolution-switcher.js?W:319)
    at HTMLDivElement.e (video.min.js?W:18)
    at HTMLDivElement.e (video.min.js?W:18)
    at HTMLDivElement.d.dispatcher.d.dispatcher (video.min.js?W:18)
    at Object.k [as trigger] (video.min.js?W:18)
    at b.a.trigger (video.min.js?W:12)
    at b.handleTechPlay_ (video.min.js?W:15)
    at constructor.e (video.min.js?W:18)