### PR TITLE
Check for videojs.default then fallback to videojs when videojs is not global

### DIFF
--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -363,5 +363,5 @@
 
     // register the plugin
     videojs.plugin('videoJsResolutionSwitcher', videoJsResolutionSwitcher);
-  })(window, videojs);
+  })(window, videojs.default || videojs);
 })();


### PR DESCRIPTION
I ran into an issue when trying to import this package, it said that videojs.getComponent is not a function. Then i found out where this issue came from and make a minor fix for it.
So hope you could merge this soon.