### PR TITLE
Update to videojs 7 and fixes

### DIFF
--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -58,11 +58,11 @@
         this.controlText('Quality');
 
         if(options.dynamicLabel){
-          videojs.addClass(this.label, 'vjs-resolution-button-label');
+          videojs.dom.addClass(this.label, 'vjs-resolution-button-label');
           this.el().appendChild(this.label);
         }else{
           var staticLabel = document.createElement('span');
-          videojs.addClass(staticLabel, 'vjs-menu-icon');
+          videojs.dom.addClass(staticLabel, 'vjs-menu-icon');
           this.el().appendChild(staticLabel);
         }
         player.on('updateSources', videojs.bind( this, this.update ) );
@@ -362,6 +362,6 @@
     };
 
     // register the plugin
-    videojs.plugin('videoJsResolutionSwitcher', videoJsResolutionSwitcher);
+    videojs.registerPlugin('videoJsResolutionSwitcher', videoJsResolutionSwitcher);
   })(window, videojs);
 })();

--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -37,8 +37,6 @@
     ResolutionMenuItem.prototype.handleClick = function(event){
       MenuItem.prototype.handleClick.call(this, event);
       this.player_.currentResolution(this.options_.label);
-      // this.player_.updateSrc(this.player_.options_.sources)
-      // MenuButton.prototype.update.call(this);
     };
     ResolutionMenuItem.prototype.update = function(){
       var selection = (this.player_ && this.player_.currentResolution() ) ? this.player_.currentResolution() : null ;

--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -31,16 +31,20 @@
         MenuItem.call(this, player, options);
         this.src = options.src;
 
-        player.on('resolutionchange', videojs.bind(this, this.update));
+        player.on('resolutionchange', videojs.bind(this, this.update))
       }
     } );
     ResolutionMenuItem.prototype.handleClick = function(event){
-      MenuItem.prototype.handleClick.call(this,event);
+      MenuItem.prototype.handleClick.call(this, event);
       this.player_.currentResolution(this.options_.label);
+      // this.player_.updateSrc(this.player_.options_.sources)
+      // MenuButton.prototype.update.call(this);
     };
     ResolutionMenuItem.prototype.update = function(){
-      var selection = this.player_.currentResolution();
-      this.selected(this.options_.label === selection.label);
+      var selection = (this.player_ && this.player_.currentResolution() ) ? this.player_.currentResolution() : null ;
+      if ( selection ) {
+        this.selected(this.options_.label === selection.label);
+      }
     };
     MenuItem.registerComponent('ResolutionMenuItem', ResolutionMenuItem);
 
@@ -56,7 +60,6 @@
         MenuButton.call(this, player, options);
         this.el().setAttribute('aria-label','Quality');
         this.controlText('Quality');
-
         if(options.dynamicLabel){
           videojs.dom.addClass(this.label, 'vjs-resolution-button-label');
           this.el().appendChild(this.label);
@@ -65,6 +68,14 @@
           videojs.dom.addClass(staticLabel, 'vjs-menu-icon');
           this.el().appendChild(staticLabel);
         }
+
+        // Make hover on resolution button
+        this.el().addEventListener('mouseover', function(e) {
+          videojs.dom.addClass(this, 'vjs-hover');
+        });
+
+        // force update of resolution to change label
+        player.on('resolutionchange', videojs.bind(this, this.update))
         player.on('updateSources', videojs.bind( this, this.update ) );
       }
     } );
@@ -94,6 +105,7 @@
       return MenuButton.prototype.update.call(this);
     };
     ResolutionMenuButton.prototype.buildCSSClass = function(){
+      videojs.dom.addClass(this.el(), 'vjs-resolution-button')
       return MenuButton.prototype.buildCSSClass.call( this ) + ' vjs-resolution-button';
     };
     MenuButton.registerComponent('ResolutionMenuButton', ResolutionMenuButton);
@@ -151,7 +163,6 @@
        */
       player.currentResolution = function(label, customSourcePicker){
         if(label == null) { return this.currentResolutionState; }
-
         // Lookup sources for label
         if(!this.groupedSrc || !this.groupedSrc.label || !this.groupedSrc.label[label]){
           return;
@@ -181,7 +192,8 @@
             player.handleTechSeeked_();
             if(!isPaused){
               // Start playing and hide loadingSpinner (flash issue ?)
-              player.play().handleTechSeeked_();
+              player.play();
+              player.handleTechSeeked_();
             }
             player.trigger('resolutionchange');
           });

--- a/lib/videojs-resolution-switcher.js
+++ b/lib/videojs-resolution-switcher.js
@@ -31,7 +31,7 @@
         MenuItem.call(this, player, options);
         this.src = options.src;
 
-        player.on('resolutionchange', videojs.bind(this, this.update))
+        player.on('resolutionchange', videojs.bind(this, this.update));
       }
     } );
     ResolutionMenuItem.prototype.handleClick = function(event){
@@ -73,7 +73,7 @@
         });
 
         // force update of resolution to change label
-        player.on('resolutionchange', videojs.bind(this, this.update))
+        player.on('resolutionchange', videojs.bind(this, this.update));
         player.on('updateSources', videojs.bind( this, this.update ) );
       }
     } );
@@ -103,7 +103,7 @@
       return MenuButton.prototype.update.call(this);
     };
     ResolutionMenuButton.prototype.buildCSSClass = function(){
-      videojs.dom.addClass(this.el(), 'vjs-resolution-button')
+      videojs.dom.addClass(this.el(), 'vjs-resolution-button');
       return MenuButton.prototype.buildCSSClass.call( this ) + ' vjs-resolution-button';
     };
     MenuButton.registerComponent('ResolutionMenuButton', ResolutionMenuButton);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "videojs-youtube": "^2.0.8"
   },
   "peerDependencies": {
-    "video.js": "^5.8"
+    "video.js": "^7.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-qunit": "^1.1",
     "grunt-contrib-uglify": "^1.0",
     "grunt-contrib-watch": "^1.0",
-    "video.js": "^5.8",
+    "video.js": "^7.4.1",
     "qunitjs": "^1.22",
     "videojs-youtube": "^2.0.8"
   },


### PR DESCRIPTION
I have the feeling that this project is abandoned, which is sad as it is the most used resolution switch plugin for videojs, although i made same changes that work for me when using videojs v7

This pull request includes the changes:
- registerPlugin()
- dom.addClass()
- Make resolution hover
- changed to handleTechSeeked_
- force resolution switch to change label